### PR TITLE
Remove unused `max` aggregate

### DIFF
--- a/src/Recorders/NotFoundRecorder.php
+++ b/src/Recorders/NotFoundRecorder.php
@@ -48,6 +48,6 @@ class NotFoundRecorder
             type: 'page_not_found',
             key: json_encode([$request->method(), $request->getUri()], flags: JSON_THROW_ON_ERROR),
             timestamp: $startedAt,
-        )->max()->count();
+        )->count();
     }
 }


### PR DESCRIPTION
This is excellent. Love seeing some cards in the wild.

Just took a look over it. You can remove the `max` call here, as you aren't collecting any values to keep a "max" of, nor are you displaying the `max` aggregate anywhere.

The `count` aggregate allows you to sort by the number of times the value is seen, which means you can show a "leaderboard" card with the URLs hit most that respond with a `404`, which I believe is the intention of the card.

Thanks for building one of the very first cards for Pulse 🎉