### PR TITLE
php 8.4 and Laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,19 +13,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [10.*, 11.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
           - laravel: 11.*
             testbench: 9.*
             carbon: ^3.0
-        exclude:
-          - laravel: 11.*
-            php: 8.1
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.8
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.14.0",
         "illuminate/contracts": "^11.0|^12.0",
-        "laravel/pulse": "^1.0"
+        "laravel/pulse": "^1.3.1"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3",
+        "php": "^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0",
-        "laravel/pulse": "^1.0@beta"
+        "illuminate/contracts": "^11.0|^12.0",
+        "laravel/pulse": "^1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8|^8.0",
-        "orchestra/testbench": "^8.8|^9.0",
+        "orchestra/testbench": "^9.0|^10.0",
         "pestphp/pest": "^2.20",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0"
@@ -72,6 +72,6 @@
             ]
         }
     },
-    "minimum-stability": "beta",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
This PR drops Laravel 10 and php8.1 since Laravel 10 is no longer supported and 11+ does not support php8.1 https://laravel.com/docs/12.x/releases#support-policy

It also drops beta support for Laravel Pulse since they are currently on v1.4. https://github.com/laravel/pulse/releases