### PR TITLE
add php8.5, laravel13, and drop laravel11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,16 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [11.*, 12.*]
+        php: [8.5 8.4, 8.3, 8.2]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: ^3.0
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.8
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.11
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.5 8.4, 8.3, 8.2]
+        php: [8.5, 8.4, 8.3, 8.2]
         laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     ],
     "require": {
-        "php": "^8.2|^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4|^8.5",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^11.0|^12.0",
-        "laravel/pulse": "^1.3.1"
+        "illuminate/contracts": "^12.0|^13.0",
+        "laravel/pulse": "^1.7.3"
     },
     "require-dev": {
-        "laravel/pint": "^1.0",
+        "laravel/pint": "^1.26",
         "nunomaduro/collision": "^7.8|^8.0",
-        "orchestra/testbench": "^9.0|^10.0",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0"
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^3.8|^4.5",
+        "pestphp/pest-plugin-arch": "^3.1|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.2|^4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR drops Laravel 11 since it is no longer supported and adds php8.5 and Laravel 13.